### PR TITLE
Optional typ field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,14 +52,14 @@ pub type Payload = BTreeMap<String, Value>;
 #[derive(Serialize, Deserialize)]
 pub struct Header {
     alg: Algorithm,
-    typ: String,
+    typ: Option<String>,
 }
 
 impl Header {
     pub fn new(alg: Algorithm) -> Header {
         Header {
             alg: alg,
-            typ: String::from("JWT"),
+            typ: Some(String::from("JWT")),
         }
     }
 }


### PR DESCRIPTION
typ field is not mandatory: Google Firebase tokens do not have it, for instance and that causes an error with the valid Firebase tokens.